### PR TITLE
Return null if casting an empty string to a date

### DIFF
--- a/lib/schema/date.js
+++ b/lib/schema/date.js
@@ -209,7 +209,7 @@ SchemaDate.prototype.max = function(value, message) {
 SchemaDate.prototype.cast = function(value) {
   // If null or undefined
   if (value == null || value === '')
-    return value;
+    return null;
 
   if (value instanceof Date)
     return value;


### PR DESCRIPTION
This fixes #3134: Empty strings are being saved for date types. Casting an empty string to a date should return null not `''`.

It looks like this was accidentally changed in the fix for #2272 commit 0ac0596368394edec115a47fb78d148f67ea29af
